### PR TITLE
Add programmatic main menu scene

### DIFF
--- a/Assets.meta
+++ b/Assets.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6b19d4cd8f3e44cfbf0ad88c35e9a0d9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project.meta
+++ b/Assets/_Project.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3c9f2fd0c6e84a29978b37efae7600f9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scenes.meta
+++ b/Assets/_Project/Scenes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 73ef0ebbbf35458797ae90d011c7baa0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scenes/MainMenu.unity
+++ b/Assets/_Project/Scenes/MainMenu.unity
@@ -1,0 +1,203 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.42, b: 0.42, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVREnvironmentMIS: 1
+    m_PVREnvironmentMISImportanceSampleCount: 256
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &1000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1001}
+  - component: {fileID: 1002}
+  - component: {fileID: 1003}
+  - component: {fileID: 1004}
+  m_Layer: 0
+  m_Name: MenuSystems
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!81 &1002
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000}
+  m_Enabled: 1
+--- !u!114 &1003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 60f4cc7f3c6b4f4f90e13d6d77ec2a3d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  panelSettings: {fileID: 0}
+  panelCredits: {fileID: 0}
+  panelLoading: {fileID: 0}
+  loadingBar: {fileID: 0}
+  loadingText: {fileID: 0}
+  sliderMasterVolume: {fileID: 0}
+  sliderSensitivity: {fileID: 0}
+  dropdownRenderScale: {fileID: 0}
+  togglePixelPerfect: {fileID: 0}
+  quitButton: {fileID: 0}
+--- !u!114 &1004
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f923d02904545cbbf63cead8d1acc40, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  campaignSceneName: Game_Scene
+  endlessSceneName: Endless_Scene
+  backgroundColor: {r: 0.101, g: 0.11, b: 0.161, a: 1}
+  panelColor: {r: 0.125, g: 0.145, b: 0.204, a: 0.92}
+  referenceResolution: {x: 1280, y: 720}

--- a/Assets/_Project/Scenes/MainMenu.unity.meta
+++ b/Assets/_Project/Scenes/MainMenu.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a6a02c1a026d42219d81b8b8e0884e70
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts.meta
+++ b/Assets/_Project/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9149c9f1d5a741a3b1cf1911091cf07a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/MenuBuilder.cs
+++ b/Assets/_Project/Scripts/MenuBuilder.cs
@@ -1,0 +1,509 @@
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+namespace OneFingerLullaby.UI
+{
+    /// <summary>
+    /// Programmatically builds the main menu hierarchy so that the scene can be
+    /// generated in environments without the Unity editor.
+    /// </summary>
+    [DefaultExecutionOrder(-200)]
+    public class MenuBuilder : MonoBehaviour
+    {
+        [Header("Scenes")]
+        [SerializeField] private string campaignSceneName = "Game_Scene";
+        [SerializeField] private string endlessSceneName = "Endless_Scene";
+
+        [Header("Visuals")]
+        [SerializeField] private Color backgroundColor = new Color(0.101f, 0.110f, 0.161f, 1f);
+        [SerializeField] private Color panelColor = new Color(0.125f, 0.145f, 0.204f, 0.92f);
+        [SerializeField] private Vector2 referenceResolution = new Vector2(1280f, 720f);
+
+        private MenuManager menuManager;
+
+        private void Awake()
+        {
+            menuManager = GetComponent<MenuManager>();
+            if (menuManager == null)
+            {
+                Debug.LogError("MenuBuilder requires a MenuManager component on the same GameObject.", this);
+                return;
+            }
+
+            var canvas = BuildCanvas();
+            BuildEventSystem();
+
+            CreateBackground(canvas.transform);
+            CreateTitle(canvas.transform);
+
+            var buttonPlay = CreateMenuButton(canvas.transform, "Button_Play", new Vector2(0, 140), "PLAY");
+            buttonPlay.onClick.AddListener(() => menuManager.PlayGame(campaignSceneName));
+
+            var buttonEndless = CreateMenuButton(canvas.transform, "Button_Endless", new Vector2(0, 70), "ENDLESS");
+            buttonEndless.onClick.AddListener(() => menuManager.PlayGame(endlessSceneName));
+
+            var buttonSettings = CreateMenuButton(canvas.transform, "Button_Settings", new Vector2(0, 0), "SETTINGS");
+            buttonSettings.onClick.AddListener(menuManager.OpenSettings);
+
+            var buttonCredits = CreateMenuButton(canvas.transform, "Button_Credits", new Vector2(0, -70), "CREDITS");
+            buttonCredits.onClick.AddListener(menuManager.OpenCredits);
+
+            var buttonQuit = CreateMenuButton(canvas.transform, "Button_Quit", new Vector2(0, -140), "QUIT");
+            buttonQuit.onClick.AddListener(menuManager.QuitGame);
+
+            var settingsPanel = BuildSettingsPanel(canvas.transform);
+            var creditsPanel = BuildCreditsPanel(canvas.transform);
+            var loadingPanel = BuildLoadingPanel(canvas.transform);
+
+            menuManager.ConfigureUI(
+                settingsPanel.gameObject,
+                creditsPanel.gameObject,
+                loadingPanel.gameObject,
+                loadingPanel.loadingBar,
+                loadingPanel.loadingText,
+                settingsPanel.masterVolume,
+                settingsPanel.sensitivity,
+                settingsPanel.renderScaleDropdown,
+                settingsPanel.pixelPerfectToggle,
+                buttonQuit.gameObject);
+
+            settingsPanel.closeButton.onClick.AddListener(menuManager.CloseSettings);
+            creditsPanel.closeButton.onClick.AddListener(menuManager.CloseCredits);
+        }
+
+        private Canvas BuildCanvas()
+        {
+            var canvasGo = new GameObject("Canvas", typeof(RectTransform), typeof(Canvas), typeof(CanvasScaler), typeof(GraphicRaycaster));
+            var rect = canvasGo.GetComponent<RectTransform>();
+            rect.SetParent(transform, false);
+            rect.anchorMin = Vector2.zero;
+            rect.anchorMax = Vector2.one;
+            rect.sizeDelta = Vector2.zero;
+            rect.anchoredPosition = Vector2.zero;
+
+            var canvas = canvasGo.GetComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            canvas.pixelPerfect = false;
+
+            var scaler = canvasGo.GetComponent<CanvasScaler>();
+            scaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+            scaler.referenceResolution = referenceResolution;
+            scaler.screenMatchMode = CanvasScaler.ScreenMatchMode.MatchWidthOrHeight;
+            scaler.matchWidthOrHeight = 0.5f;
+
+            return canvas;
+        }
+
+        private void BuildEventSystem()
+        {
+            if (FindObjectOfType<EventSystem>() != null)
+            {
+                return;
+            }
+
+            var eventSystemGo = new GameObject("EventSystem", typeof(EventSystem), typeof(StandaloneInputModule));
+            eventSystemGo.transform.SetParent(transform, false);
+        }
+
+        private void CreateBackground(Transform parent)
+        {
+            var image = CreateImage("Panel_Background", parent, backgroundColor, Vector2.zero, Vector2.zero);
+            var rect = image.rectTransform;
+            rect.anchorMin = Vector2.zero;
+            rect.anchorMax = Vector2.one;
+            rect.offsetMin = Vector2.zero;
+            rect.offsetMax = Vector2.zero;
+            image.raycastTarget = false;
+        }
+
+        private void CreateTitle(Transform parent)
+        {
+            var title = CreateText("Title", parent, new Vector2(0f, -60f), new Vector2(600f, 120f), "DOG DISTRACTION", 72);
+            var rect = title.rectTransform;
+            rect.anchorMin = new Vector2(0.5f, 1f);
+            rect.anchorMax = new Vector2(0.5f, 1f);
+            rect.pivot = new Vector2(0.5f, 1f);
+            title.alignment = TextAlignmentOptions.Center;
+            title.fontStyle = FontStyles.UpperCase | FontStyles.Bold;
+        }
+
+        private Button CreateMenuButton(Transform parent, string name, Vector2 anchoredPosition, string label)
+        {
+            var go = new GameObject(name, typeof(RectTransform), typeof(Image), typeof(Button));
+            var rect = go.GetComponent<RectTransform>();
+            rect.SetParent(parent, false);
+            rect.sizeDelta = new Vector2(320f, 60f);
+            rect.anchoredPosition = anchoredPosition;
+            rect.anchorMin = rect.anchorMax = new Vector2(0.5f, 0.5f);
+
+            var image = go.GetComponent<Image>();
+            image.sprite = SpriteFromColor(Color.white);
+            image.type = Image.Type.Sliced;
+            image.color = new Color(0.25f, 0.44f, 0.64f, 1f);
+
+            var button = go.GetComponent<Button>();
+            var colors = button.colors;
+            colors.normalColor = Color.white;
+            colors.highlightedColor = new Color(0.92f, 0.96f, 0.99f, 1f);
+            colors.pressedColor = new Color(0.78f, 0.84f, 0.88f, 1f);
+            colors.selectedColor = colors.highlightedColor;
+            colors.disabledColor = new Color(0.6f, 0.6f, 0.6f, 0.5f);
+            colors.colorMultiplier = 1f;
+            colors.fadeDuration = 0.1f;
+            button.colors = colors;
+
+            var text = CreateText("Label", go.transform, Vector2.zero, Vector2.zero, label, 32);
+            var textRect = text.rectTransform;
+            textRect.anchorMin = Vector2.zero;
+            textRect.anchorMax = Vector2.one;
+            textRect.offsetMin = new Vector2(24f, 12f);
+            textRect.offsetMax = new Vector2(-24f, -12f);
+            text.alignment = TextAlignmentOptions.Center;
+            text.fontStyle = FontStyles.UpperCase | FontStyles.Bold;
+
+            return button;
+        }
+
+        private SettingsPanel BuildSettingsPanel(Transform parent)
+        {
+            var panelGo = new GameObject("Panel_Settings", typeof(RectTransform), typeof(Image));
+            var rect = panelGo.GetComponent<RectTransform>();
+            rect.SetParent(parent, false);
+            rect.sizeDelta = new Vector2(640f, 480f);
+            rect.anchorMin = rect.anchorMax = new Vector2(0.5f, 0.5f);
+            rect.anchoredPosition = Vector2.zero;
+
+            var image = panelGo.GetComponent<Image>();
+            image.color = panelColor;
+
+            var title = CreateText("Header", panelGo.transform, new Vector2(0f, -32f), new Vector2(560f, 80f), "SETTINGS", 48);
+            var titleRect = title.rectTransform;
+            titleRect.anchorMin = new Vector2(0.5f, 1f);
+            titleRect.anchorMax = new Vector2(0.5f, 1f);
+            titleRect.pivot = new Vector2(0.5f, 1f);
+            title.alignment = TextAlignmentOptions.Center;
+
+            var masterSlider = CreateSlider(panelGo.transform, "Slider_MasterVolume", new Vector2(0f, 120f));
+            masterSlider.minValue = 0f;
+            masterSlider.maxValue = 1f;
+            masterSlider.value = 0.8f;
+
+            var masterLabel = CreateText("Label_Master", panelGo.transform, new Vector2(-200f, 120f), new Vector2(220f, 40f), "Master Volume", 28);
+            masterLabel.alignment = TextAlignmentOptions.MidlineRight;
+
+            var sensitivitySlider = CreateSlider(panelGo.transform, "Slider_Sensitivity", new Vector2(0f, 40f));
+            sensitivitySlider.minValue = 0.5f;
+            sensitivitySlider.maxValue = 2f;
+            sensitivitySlider.value = 1f;
+
+            var sensitivityLabel = CreateText("Label_Sensitivity", panelGo.transform, new Vector2(-200f, 40f), new Vector2(220f, 40f), "Sensitivity", 28);
+            sensitivityLabel.alignment = TextAlignmentOptions.MidlineRight;
+
+            var dropdown = CreateDropdown(panelGo.transform, "Dropdown_RenderScale", new Vector2(0f, -60f));
+            dropdown.options = new List<TMP_Dropdown.OptionData>
+            {
+                new TMP_Dropdown.OptionData("100%"),
+                new TMP_Dropdown.OptionData("150%"),
+                new TMP_Dropdown.OptionData("200%")
+            };
+            dropdown.value = 0;
+            dropdown.RefreshShownValue();
+
+            var renderScaleLabel = CreateText("Label_RenderScale", panelGo.transform, new Vector2(-220f, -60f), new Vector2(240f, 40f), "Render Scale", 28);
+            renderScaleLabel.alignment = TextAlignmentOptions.MidlineRight;
+
+            var toggle = CreateToggle(panelGo.transform, "Toggle_PixelPerfect", new Vector2(-160f, -160f));
+            toggle.isOn = true;
+
+            var toggleLabel = toggle.GetComponentInChildren<TextMeshProUGUI>();
+            if (toggleLabel != null)
+            {
+                toggleLabel.text = "Pixel Perfect";
+                toggleLabel.fontSize = 28f;
+                toggleLabel.alignment = TextAlignmentOptions.MidlineLeft;
+                var toggleRect = toggleLabel.rectTransform;
+                toggleRect.offsetMin = new Vector2(30f, -20f);
+                toggleRect.offsetMax = new Vector2(0f, 20f);
+            }
+
+            var closeButton = CreateMenuButton(panelGo.transform, "Button_CloseSettings", new Vector2(0f, -200f), "CLOSE");
+            closeButton.onClick.AddListener(() => panelGo.SetActive(false));
+
+            panelGo.SetActive(false);
+
+            return new SettingsPanel
+            {
+                gameObject = panelGo,
+                masterVolume = masterSlider,
+                sensitivity = sensitivitySlider,
+                renderScaleDropdown = dropdown,
+                pixelPerfectToggle = toggle,
+                closeButton = closeButton
+            };
+        }
+
+        private CreditsPanel BuildCreditsPanel(Transform parent)
+        {
+            var panelGo = new GameObject("Panel_Credits", typeof(RectTransform), typeof(Image));
+            var rect = panelGo.GetComponent<RectTransform>();
+            rect.SetParent(parent, false);
+            rect.sizeDelta = new Vector2(640f, 480f);
+            rect.anchorMin = rect.anchorMax = new Vector2(0.5f, 0.5f);
+            rect.anchoredPosition = Vector2.zero;
+
+            var image = panelGo.GetComponent<Image>();
+            image.color = panelColor;
+
+            var title = CreateText("Header", panelGo.transform, new Vector2(0f, -32f), new Vector2(560f, 80f), "CREDITS", 48);
+            var titleRect = title.rectTransform;
+            titleRect.anchorMin = new Vector2(0.5f, 1f);
+            titleRect.anchorMax = new Vector2(0.5f, 1f);
+            titleRect.pivot = new Vector2(0.5f, 1f);
+            title.alignment = TextAlignmentOptions.Center;
+
+            var creditsText = CreateText(
+                "CreditsText",
+                panelGo.transform,
+                new Vector2(0f, -40f),
+                new Vector2(560f, 260f),
+                "Design & Code: OpenAI Assistant\nMusic: Your Name Here\nSpecial Thanks: One Finger Lullaby Team",
+                28);
+            var creditsRect = creditsText.rectTransform;
+            creditsRect.anchorMin = new Vector2(0.5f, 1f);
+            creditsRect.anchorMax = new Vector2(0.5f, 1f);
+            creditsRect.pivot = new Vector2(0.5f, 1f);
+            creditsText.alignment = TextAlignmentOptions.Top;
+            creditsText.enableWordWrapping = true;
+
+            var closeButton = CreateMenuButton(panelGo.transform, "Button_CloseCredits", new Vector2(0f, -200f), "CLOSE");
+            closeButton.onClick.AddListener(() => panelGo.SetActive(false));
+
+            panelGo.SetActive(false);
+
+            return new CreditsPanel
+            {
+                gameObject = panelGo,
+                closeButton = closeButton
+            };
+        }
+
+        private LoadingPanel BuildLoadingPanel(Transform parent)
+        {
+            var panelGo = new GameObject("Panel_Loading", typeof(RectTransform), typeof(Image));
+            var rect = panelGo.GetComponent<RectTransform>();
+            rect.SetParent(parent, false);
+            rect.sizeDelta = new Vector2(480f, 200f);
+            rect.anchorMin = rect.anchorMax = new Vector2(0.5f, 0.5f);
+            rect.anchoredPosition = Vector2.zero;
+
+            var image = panelGo.GetComponent<Image>();
+            image.color = new Color(0f, 0f, 0f, 0.6f);
+
+            var text = CreateText("LoadingText", panelGo.transform, new Vector2(0f, 40f), new Vector2(440f, 60f), "Loading...", 32);
+            text.alignment = TextAlignmentOptions.Center;
+
+            var bar = CreateImage("LoadingBar", panelGo.transform, new Color(0.26f, 0.54f, 0.69f, 1f), new Vector2(0f, -40f), new Vector2(420f, 30f));
+            var barRect = bar.rectTransform;
+            barRect.anchorMin = barRect.anchorMax = new Vector2(0.5f, 0.5f);
+            bar.type = Image.Type.Filled;
+            bar.fillMethod = Image.FillMethod.Horizontal;
+            bar.fillAmount = 0f;
+
+            panelGo.SetActive(false);
+
+            return new LoadingPanel
+            {
+                gameObject = panelGo,
+                loadingText = text,
+                loadingBar = bar
+            };
+        }
+
+        private TextMeshProUGUI CreateText(string name, Transform parent, Vector2 anchoredPosition, Vector2 size, string text, int fontSize)
+        {
+            var go = new GameObject(name, typeof(RectTransform), typeof(TextMeshProUGUI));
+            var rect = go.GetComponent<RectTransform>();
+            rect.SetParent(parent, false);
+            rect.sizeDelta = size;
+            rect.anchoredPosition = anchoredPosition;
+
+            var tmp = go.GetComponent<TextMeshProUGUI>();
+            tmp.text = text;
+            tmp.fontSize = fontSize;
+            tmp.color = new Color(0.96f, 0.96f, 0.96f, 1f);
+            tmp.enableWordWrapping = false;
+            tmp.alignment = TextAlignmentOptions.Left;
+            if (TMP_Settings.defaultFontAsset != null)
+            {
+                tmp.font = TMP_Settings.defaultFontAsset;
+            }
+
+            return tmp;
+        }
+
+        private Image CreateImage(string name, Transform parent, Color color, Vector2 anchoredPosition, Vector2 size)
+        {
+            var go = new GameObject(name, typeof(RectTransform), typeof(Image));
+            var rect = go.GetComponent<RectTransform>();
+            rect.SetParent(parent, false);
+            rect.sizeDelta = size;
+            rect.anchoredPosition = anchoredPosition;
+            rect.anchorMin = rect.anchorMax = new Vector2(0.5f, 0.5f);
+
+            var image = go.GetComponent<Image>();
+            image.sprite = SpriteFromColor(color);
+            image.color = Color.white;
+            image.type = Image.Type.Sliced;
+
+            return image;
+        }
+
+        private Slider CreateSlider(Transform parent, string name, Vector2 anchoredPosition)
+        {
+            var sliderGo = new GameObject(name, typeof(RectTransform), typeof(Slider));
+            var rect = sliderGo.GetComponent<RectTransform>();
+            rect.SetParent(parent, false);
+            rect.sizeDelta = new Vector2(360f, 30f);
+            rect.anchorMin = rect.anchorMax = new Vector2(0.5f, 0.5f);
+            rect.anchoredPosition = anchoredPosition;
+
+            var slider = sliderGo.GetComponent<Slider>();
+            slider.transition = Selectable.Transition.ColorTint;
+
+            var background = CreateImage("Background", sliderGo.transform, new Color(0.07f, 0.07f, 0.09f, 1f), Vector2.zero, Vector2.zero);
+            var backgroundRect = background.rectTransform;
+            backgroundRect.anchorMin = Vector2.zero;
+            backgroundRect.anchorMax = Vector2.one;
+            backgroundRect.offsetMin = Vector2.zero;
+            backgroundRect.offsetMax = Vector2.zero;
+            background.type = Image.Type.Sliced;
+
+            var fillArea = new GameObject("Fill Area", typeof(RectTransform));
+            var fillAreaRect = fillArea.GetComponent<RectTransform>();
+            fillAreaRect.SetParent(sliderGo.transform, false);
+            fillAreaRect.anchorMin = new Vector2(0f, 0.25f);
+            fillAreaRect.anchorMax = new Vector2(1f, 0.75f);
+            fillAreaRect.offsetMin = new Vector2(12f, 0f);
+            fillAreaRect.offsetMax = new Vector2(-28f, 0f);
+
+            var fill = CreateImage("Fill", fillArea.transform, new Color(0.26f, 0.54f, 0.69f, 1f), Vector2.zero, Vector2.zero);
+            var fillRect = fill.rectTransform;
+            fillRect.anchorMin = new Vector2(0f, 0f);
+            fillRect.anchorMax = new Vector2(1f, 1f);
+            fillRect.offsetMin = Vector2.zero;
+            fillRect.offsetMax = Vector2.zero;
+
+            var handleArea = new GameObject("Handle Slide Area", typeof(RectTransform));
+            var handleAreaRect = handleArea.GetComponent<RectTransform>();
+            handleAreaRect.SetParent(sliderGo.transform, false);
+            handleAreaRect.anchorMin = Vector2.zero;
+            handleAreaRect.anchorMax = Vector2.one;
+            handleAreaRect.offsetMin = new Vector2(12f, 0f);
+            handleAreaRect.offsetMax = new Vector2(-12f, 0f);
+
+            var handle = CreateImage("Handle", handleArea.transform, new Color(0.92f, 0.93f, 0.96f, 1f), Vector2.zero, new Vector2(24f, 24f));
+            var handleRect = handle.rectTransform;
+            handleRect.anchorMin = new Vector2(0f, 0.5f);
+            handleRect.anchorMax = new Vector2(0f, 0.5f);
+            handleRect.pivot = new Vector2(0.5f, 0.5f);
+
+            slider.fillRect = fillRect;
+            slider.handleRect = handleRect;
+            slider.targetGraphic = handle;
+
+            return slider;
+        }
+
+        private TMP_Dropdown CreateDropdown(Transform parent, string name, Vector2 anchoredPosition)
+        {
+            var resources = GetDefaultResources();
+            var dropdownGo = TMP_DefaultControls.CreateDropdown(resources);
+            dropdownGo.name = name;
+            var rect = dropdownGo.GetComponent<RectTransform>();
+            rect.SetParent(parent, false);
+            rect.sizeDelta = new Vector2(260f, 40f);
+            rect.anchorMin = rect.anchorMax = new Vector2(0.5f, 0.5f);
+            rect.anchoredPosition = anchoredPosition;
+
+            var dropdown = dropdownGo.GetComponent<TMP_Dropdown>();
+            dropdown.captionText.color = new Color(0.96f, 0.96f, 0.96f, 1f);
+            dropdown.itemText.color = new Color(0.96f, 0.96f, 0.96f, 1f);
+
+            return dropdown;
+        }
+
+        private Toggle CreateToggle(Transform parent, string name, Vector2 anchoredPosition)
+        {
+            var resources = GetDefaultResources();
+            var toggleGo = TMP_DefaultControls.CreateToggle(resources);
+            toggleGo.name = name;
+            var rect = toggleGo.GetComponent<RectTransform>();
+            rect.SetParent(parent, false);
+            rect.sizeDelta = new Vector2(200f, 40f);
+            rect.anchorMin = rect.anchorMax = new Vector2(0.5f, 0.5f);
+            rect.anchoredPosition = anchoredPosition;
+
+            var toggle = toggleGo.GetComponent<Toggle>();
+            toggle.graphic.color = new Color(0.26f, 0.54f, 0.69f, 1f);
+
+            return toggle;
+        }
+
+        private TMP_DefaultControls.Resources GetDefaultResources()
+        {
+            return new TMP_DefaultControls.Resources
+            {
+                standard = SpriteFromColor(new Color(0.18f, 0.20f, 0.28f, 1f)),
+                background = SpriteFromColor(new Color(0.14f, 0.15f, 0.22f, 1f)),
+                inputField = SpriteFromColor(new Color(0.12f, 0.13f, 0.18f, 1f)),
+                knob = SpriteFromColor(new Color(0.92f, 0.93f, 0.96f, 1f)),
+                checkmark = SpriteFromColor(new Color(0.26f, 0.54f, 0.69f, 1f)),
+                dropdown = SpriteFromColor(new Color(0.18f, 0.20f, 0.28f, 1f)),
+                mask = SpriteFromColor(Color.white)
+            };
+        }
+
+        private Sprite SpriteFromColor(Color color)
+        {
+            var texture = new Texture2D(2, 2)
+            {
+                name = $"Color_{color.r:F2}_{color.g:F2}_{color.b:F2}",
+                hideFlags = HideFlags.HideAndDontSave
+            };
+            var fillColor = new Color(color.r, color.g, color.b, 1f);
+            var pixels = new Color[4] { fillColor, fillColor, fillColor, fillColor };
+            texture.SetPixels(pixels);
+            texture.Apply();
+
+            var sprite = Sprite.Create(texture, new Rect(0f, 0f, texture.width, texture.height), new Vector2(0.5f, 0.5f), 100f);
+            sprite.hideFlags = HideFlags.HideAndDontSave;
+            return sprite;
+        }
+
+        private struct SettingsPanel
+        {
+            public GameObject gameObject;
+            public Slider masterVolume;
+            public Slider sensitivity;
+            public TMP_Dropdown renderScaleDropdown;
+            public Toggle pixelPerfectToggle;
+            public Button closeButton;
+        }
+
+        private struct CreditsPanel
+        {
+            public GameObject gameObject;
+            public Button closeButton;
+        }
+
+        private struct LoadingPanel
+        {
+            public GameObject gameObject;
+            public TMP_Text loadingText;
+            public Image loadingBar;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/MenuBuilder.cs.meta
+++ b/Assets/_Project/Scripts/MenuBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5f923d02904545cbbf63cead8d1acc40
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/MenuManager.cs
+++ b/Assets/_Project/Scripts/MenuManager.cs
@@ -1,0 +1,251 @@
+using System.Collections;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.UI;
+
+namespace OneFingerLullaby.UI
+{
+    /// <summary>
+    /// Controls high level behaviour for the main menu including button events,
+    /// settings defaults, and asynchronous scene loading feedback.
+    /// </summary>
+    public class MenuManager : MonoBehaviour
+    {
+        [Header("Panels")]
+        [SerializeField] private GameObject panelSettings;
+        [SerializeField] private GameObject panelCredits;
+        [SerializeField] private GameObject panelLoading;
+
+        [Header("Loading UI")]
+        [SerializeField] private Image loadingBar;
+        [SerializeField] private TMP_Text loadingText;
+
+        [Header("Settings UI")]
+        [SerializeField] private Slider sliderMasterVolume;
+        [SerializeField] private Slider sliderSensitivity;
+        [SerializeField] private TMP_Dropdown dropdownRenderScale;
+        [SerializeField] private Toggle togglePixelPerfect;
+
+        [Header("Platform UI")]
+        [SerializeField] private GameObject quitButton;
+
+        private const float MasterVolumeDefault = 0.8f;
+        private const float SensitivityDefault = 1.0f;
+
+        private Coroutine loadRoutine;
+
+        private void Awake()
+        {
+            HandlePlatformSpecificUI();
+        }
+
+        /// <summary>
+        /// Begin loading a scene asynchronously. Shows loading progress while the scene loads.
+        /// </summary>
+        /// <param name="sceneName">The scene to load. Must be added to build settings.</param>
+        public void PlayGame(string sceneName)
+        {
+            if (string.IsNullOrWhiteSpace(sceneName))
+            {
+                Debug.LogWarning("MenuManager.PlayGame called with an invalid scene name.");
+                return;
+            }
+
+            if (loadRoutine != null)
+            {
+                StopCoroutine(loadRoutine);
+            }
+
+            loadRoutine = StartCoroutine(LoadSceneAsync(sceneName));
+        }
+
+        public void OpenSettings()
+        {
+            CloseAllPanels();
+            Show(panelSettings);
+        }
+
+        public void CloseSettings()
+        {
+            Hide(panelSettings);
+        }
+
+        public void OpenCredits()
+        {
+            CloseAllPanels();
+            Show(panelCredits);
+        }
+
+        public void CloseCredits()
+        {
+            Hide(panelCredits);
+        }
+
+        public void QuitGame()
+        {
+            Debug.Log("Quit requested from main menu.");
+            Application.Quit();
+#if UNITY_EDITOR
+            UnityEditor.EditorApplication.isPlaying = false;
+#endif
+        }
+
+        private IEnumerator LoadSceneAsync(string sceneName)
+        {
+            Show(panelLoading);
+            UpdateLoadingUI(0f);
+
+            AsyncOperation operation;
+
+            try
+            {
+                operation = SceneManager.LoadSceneAsync(sceneName);
+            }
+            catch (System.Exception exception)
+            {
+                Debug.LogError($"Failed to load scene '{sceneName}': {exception}");
+                Hide(panelLoading);
+                yield break;
+            }
+
+            if (operation == null)
+            {
+                Debug.LogError($"Scene '{sceneName}' could not be loaded. Ensure it is added to Build Settings.");
+                Hide(panelLoading);
+                yield break;
+            }
+
+            while (!operation.isDone)
+            {
+                var progress = Mathf.Clamp01(operation.progress / 0.9f);
+                UpdateLoadingUI(progress);
+                yield return null;
+            }
+
+            UpdateLoadingUI(1f);
+        }
+
+        private void InitializeSettingsDefaults()
+        {
+            if (sliderMasterVolume != null)
+            {
+                sliderMasterVolume.minValue = 0f;
+                sliderMasterVolume.maxValue = 1f;
+                sliderMasterVolume.value = MasterVolumeDefault;
+            }
+
+            if (sliderSensitivity != null)
+            {
+                sliderSensitivity.minValue = 0.5f;
+                sliderSensitivity.maxValue = 2f;
+                sliderSensitivity.value = SensitivityDefault;
+            }
+
+            if (dropdownRenderScale != null)
+            {
+                var options = new List<string> { "100%", "150%", "200%" };
+                dropdownRenderScale.ClearOptions();
+                dropdownRenderScale.AddOptions(options);
+                dropdownRenderScale.value = 0;
+                dropdownRenderScale.RefreshShownValue();
+            }
+
+            if (togglePixelPerfect != null)
+            {
+                togglePixelPerfect.isOn = true;
+            }
+        }
+
+        public void ConfigureUI(
+            GameObject settingsPanel,
+            GameObject creditsPanel,
+            GameObject loadingPanel,
+            Image loadingBarImage,
+            TMP_Text loadingTextLabel,
+            Slider masterSlider,
+            Slider sensitivitySlider,
+            TMP_Dropdown renderScaleDropdown,
+            Toggle pixelPerfectToggle,
+            GameObject quitButtonObject)
+        {
+            panelSettings = settingsPanel;
+            panelCredits = creditsPanel;
+            panelLoading = loadingPanel;
+            loadingBar = loadingBarImage;
+            loadingText = loadingTextLabel;
+            sliderMasterVolume = masterSlider;
+            sliderSensitivity = sensitivitySlider;
+            dropdownRenderScale = renderScaleDropdown;
+            togglePixelPerfect = pixelPerfectToggle;
+            quitButton = quitButtonObject;
+
+            HideImmediate(panelSettings);
+            HideImmediate(panelCredits);
+            HideImmediate(panelLoading);
+
+            InitializeSettingsDefaults();
+            HandlePlatformSpecificUI();
+        }
+
+        private void HandlePlatformSpecificUI()
+        {
+#if UNITY_IOS
+            if (quitButton != null)
+            {
+                quitButton.SetActive(false);
+            }
+#else
+            if (quitButton != null)
+            {
+                quitButton.SetActive(true);
+            }
+#endif
+        }
+
+        private void UpdateLoadingUI(float progress)
+        {
+            if (loadingBar != null)
+            {
+                loadingBar.fillAmount = progress;
+            }
+
+            if (loadingText != null)
+            {
+                var percentage = Mathf.RoundToInt(progress * 100f);
+                loadingText.text = progress >= 1f ? "Ready" : $"Loading... {percentage}%";
+            }
+        }
+
+        private void CloseAllPanels()
+        {
+            Hide(panelSettings);
+            Hide(panelCredits);
+        }
+
+        private static void Hide(GameObject target)
+        {
+            if (target != null)
+            {
+                target.SetActive(false);
+            }
+        }
+
+        private static void HideImmediate(GameObject target)
+        {
+            if (target != null)
+            {
+                target.SetActive(false);
+            }
+        }
+
+        private static void Show(GameObject target)
+        {
+            if (target != null)
+            {
+                target.SetActive(true);
+            }
+        }
+    }
+}

--- a/Assets/_Project/Scripts/MenuManager.cs.meta
+++ b/Assets/_Project/Scripts/MenuManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 60f4cc7f3c6b4f4f90e13d6d77ec2a3d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add runtime menu management logic for playing scenes, handling settings defaults, and quitting gracefully
- build the main menu UI hierarchy at runtime so the scene can be generated without editor interaction
- add a lightweight MainMenu scene wiring MenuManager and MenuBuilder together

## Testing
- not run (Unity editor not available)


------
https://chatgpt.com/codex/tasks/task_e_68d0226992b883258736be42bd207175